### PR TITLE
Update lexicon description

### DIFF
--- a/lexicons/social/psky/feed/post.json
+++ b/lexicons/social/psky/feed/post.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "A Picosky post containing at most 12 graphemes.",
+      "description": "A Picosky post containing at most 64 graphemes.",
       "key": "tid",
       "record": {
         "type": "object",


### PR DESCRIPTION
## Why

It looks like the description for the lexicon is out of date. Posts can contain 64 graphemes but the description says 12.

## Test Plan

It runs.